### PR TITLE
add the missing dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install Docker on your machine
 For Linux:
 ```bash
 curl -sSL https://get.docker.com | sudo sh
-docker build -t deepcut 
+docker build -t deepcut .
 ```
 
 For other OS: see https://docs.docker.com/engine/installation/


### PR DESCRIPTION
The Docker `build` command requires us to specify a directory to build. Normally we build at the current directory, hence ` . `.

The README just missed the dot in the build command.
