### PR TITLE
Remove keras.json from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ RUN pip install https://pypi.python.org/packages/7d/d0/96269b9ecfcc55cb387798315
 
 RUN pip install deepcut
 
-COPY keras.json /root/.keras/
-
 WORKDIR /root
 
 ENTRYPOINT /bin/sh


### PR DESCRIPTION
Hi,

It seems `keras.json`[1] isn't in the repository anymore. However, it's still in `Dockerfile` and causes docker-build failed. 

[1] https://github.com/rkcosmos/deepcut/blob/master/Dockerfile#L39