### PR TITLE
save session for running with webbase app(Flask)

### DIFF
--- a/deepcut/deepcut.py
+++ b/deepcut/deepcut.py
@@ -133,6 +133,7 @@ class DeepcutTokenizer(object):
         self.model = get_convo_nn2()
         self.model.load_weights(WEIGHT_PATH)
         self.graph = backend.get_session().graph # save graph for reference in async
+        self.sess = backend.get_session()
 
         self.vocabulary_ = {}
         self.ngram_range = ngram_range
@@ -299,6 +300,7 @@ class DeepcutTokenizer(object):
         # Fix thread-related issue in Keras + TensorFlow + Flask async environment
         # ref: https://github.com/keras-team/keras/issues/2397
         with self.graph.as_default():
+            backend.set_session(self.sess)
             y_predict = self.model.predict([x_char, x_type])
             y_predict = (y_predict.ravel() > 0.5).astype(int)
             word_end = y_predict[1:].tolist() + [1]


### PR DESCRIPTION
Having a problem when using deepcut with [Flask](https://pypi.org/project/Flask/). First request everything just fine, but it's crash on next one. note that deepcut is working fine if it using in python interactive mode(python -i) it can predict for many times as it should be.

this is what I got from second requests with flask

    tensorflow.python.framework.errors_impl.FailedPreconditionError: Error while reading resource variable conv1d_10/bias from Container: localhost. This could mean that the variable was uninitialized. Not found: Container localhost does not exist. (Could not find resource: localhost/conv1d_10/bias)
         [[{{node conv1d_10/Reshape/ReadVariableOp}}]]

with [https://github.com/keras-team/keras/issues/2397](https://github.com/keras-team/keras/issues/2397), [https://github.com/tensorflow/tensorflow/issues/28287](https://github.com/tensorflow/tensorflow/issues/28287)   and [https://stackoverflow.com/questions/53653303/where-is-the-tensorflow-session-in-keras](https://stackoverflow.com/questions/53653303/where-is-the-tensorflow-session-in-keras) I found that using same session solved this.